### PR TITLE
Fixed: read from all partitions, not only the first one

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,8 +5,8 @@ authors:
   - Alex Malone <alex.malone@ziften.com>
 
 libraries:
-  librdkafka: 0.11.0
+  librdkafka: 1.5.0
 
-crystal: 0.23.1
+crystal: 0.35.1
 
 license: MIT

--- a/src/kafka/consumer.cr
+++ b/src/kafka/consumer.cr
@@ -25,9 +25,6 @@ module Kafka
 
       @topic_conf = LibKafkaC.topic_conf_new();
 
-      err = LibKafkaC.topic_conf_set(@topic_conf, "offset.store.method", "broker", @pErrStr, ERRLEN)
-      raise "Error setting topic conf offset.store.method #{String.new @pErrStr}" if err != LibKafkaC::OK
-
       # Set default topic config for pattern-matched topics.
       LibKafkaC.conf_set_default_topic_conf(conf, @topic_conf);
 
@@ -47,7 +44,7 @@ module Kafka
 
     # Set the topic to use for *produce()* calls.
     # Raises exception on error.
-    def set_topic_partition(name : String, partition : Int32 = 0) #LibKafkaC::PARTITION_UNASSIGNED)
+    def set_topic_partition(name : String, partition : Int32 = LibKafkaC::PARTITION_UNASSIGNED)
       raise "Can't set topic while running." if @running
 
       unless @topics
@@ -57,9 +54,8 @@ module Kafka
 
       LibKafkaC.topic_partition_list_add(@topics, name, partition)
 
-      err = LibKafkaC.assign(@handle, @topics)
-      raise "Error assigning topic partitions err=#{err}" if err != 0
-
+      err = LibKafkaC.subscribe(@handle, @topics)
+      raise "Error subscribing to topic err=#{err}" if err != 0
     end
 
     # dequeues a single message

--- a/src/kafka/lib_rdkafka.cr
+++ b/src/kafka/lib_rdkafka.cr
@@ -104,7 +104,7 @@ end
   fun topic_partition_list_add = rd_kafka_topic_partition_list_add(tplist: TopicPartitionList, topic: UInt8*, partition: Int32) : Void* # TopicPartition
   fun topic_partition_list_destroy = rd_kafka_topic_partition_list_destroy(tplist: TopicPartitionList)
   fun assign = rd_kafka_assign(rk: KafkaHandle, topics: TopicPartitionList) : Int32
-
+  fun subscribe = rd_kafka_subscribe(rk: KafkaHandle, subscription: TopicPartitionList) : Int32
 
   fun poll = rd_kafka_poll(rk: KafkaHandle, timeout_ms: Int32) : Int32
   fun flush = rd_kafka_flush(rk: KafkaHandle, timeout_ms: Int32)


### PR DESCRIPTION
When I tried to write a simple consumer, as in the example (https://github.com/packetzero/kafka_examples.cr/blob/master/src/simple_consumer.cr), it failed to see most messages. Then I realized that it only listens for messages on the first partition.

By comparing with the C library, where I did not had that issue, I noticed a small difference. It is using the `rd_kafka_subscribe` API, not `rd_kafka_assign`:

https://github.com/edenhill/librdkafka/blob/39796d359898c07ea422849e6d7cd34cd13ec466/examples/consumer.c#L180

Changing that solved it for me (i.e. it reads from all partitions now).

Also removed the deprecated option "offset.store.method". As I understand, it is the default now, anyway. Setting it results in a warning.

