### PR TITLE
Improve the producer: better error handling and fixed pool loop that locked up the worker

### DIFF
--- a/src/kafka/config.cr
+++ b/src/kafka/config.cr
@@ -18,16 +18,15 @@ module Kafka
     end
 
     def to_unsafe
-      return @conf_handle
+      @conf_handle
     end
 
     def set(name : String, value : String)
-
       res = LibKafkaC.conf_set(@conf_handle, name, value, @pErrStr, ERRLEN)
       raise "Kafka.Config: set('#{name}') failed: #{String.new @pErrStr}" unless LibKafkaC::OK == res
     end
 
-    def set_msg_callback(cb : Proc(LibKafkaC::KafkaHandle, Void*, Void*) )
+    def set_msg_callback(cb : Proc(LibKafkaC::KafkaHandle, LibKafkaC::Message*, Void*, Void) )
       LibKafkaC.conf_set_dr_msg_cb @conf_handle, cb
     end
   end

--- a/src/kafka/errors.cr
+++ b/src/kafka/errors.cr
@@ -5,10 +5,19 @@ module Kafka
     String.new(LibKafkaC.err2str(err.to_i32))
   end
 
+  def self.normalize_error(err : LibKafkaC::ResponseError) : LibKafkaC::ResponseError
+    err
+  end
+
+  def self.normalize_error(errno : Errno) : LibKafkaC::ResponseError
+    LibKafkaC.errno2err(errno)
+  end
+
   class KafkaException < Exception
     getter err : LibKafkaC::ResponseError
 
-    def initialize(message : String?, @err)
+    def initialize(message : String?, err : LibKafkaC::ResponseError | Errno)
+      @err = Kafka.normalize_error(err)
       super(format_error(message, @err))
     end
 

--- a/src/kafka/errors.cr
+++ b/src/kafka/errors.cr
@@ -1,0 +1,23 @@
+require "./lib_rdkafka.cr"
+
+module Kafka
+  def self.err2str(err : Int32 | LibKafkaC::ResponseError) : String
+    String.new(LibKafkaC.err2str(err.to_i32))
+  end
+
+  class KafkaException < Exception
+    getter err : LibKafkaC::ResponseError
+
+    def initialize(message : String?, @err)
+      super(format_error(message, @err))
+    end
+
+    private def format_error(message, err)
+      if message
+        "#{message} (code=#{err})"
+      else
+        "#{Kafka.err2str(err)} (code=#{err})"
+      end
+    end
+  end
+end

--- a/src/kafka/lib_rdkafka.cr
+++ b/src/kafka/lib_rdkafka.cr
@@ -424,6 +424,7 @@ end
 
   fun last_error = rd_kafka_last_error() : Int32
   fun err2str = rd_kafka_err2str(code : Int32) : UInt8*
+  fun errno2err = rd_kafka_errno2err(errno : Int32) : ResponseError
 
   fun conf_set_log_cb = rd_kafka_conf_set_log_cb(conf: ConfHandle, cb: (KafkaHandle, Int32, UInt32, UInt8*) -> )
   fun set_log_level = rd_kafka_set_log_level(kh: KafkaHandle, level: Int32)

--- a/src/kafka/lib_rdkafka.cr
+++ b/src/kafka/lib_rdkafka.cr
@@ -30,17 +30,330 @@ lib LibKafkaC
 #  OK = 0       # /**< Configuration okay */
 #end
 
-OK = 0
+  OK = 0
 
-MSG_FLAG_FREE = 0x1    # Delegate freeing of payload to rdkafka
-MSG_FLAG_COPY = 0x2    # rdkafka will make a copy of the payload.
-MSG_FLAG_BLOCK = 0x4   # Block produce*() on message queue full
+  enum ResponseError
+    #/* Internal errors to rdkafka: */
+    #/** Begin internal error codes */
+    BEGIN_INTERNAL_ERROR = -200
+    #/** Received message is incorrect */
+    BAD_MSG = -199
+    #/** Bad/unknown compression */
+    BAD_COMPRESSION = -198
+    #/** Broker is going away */
+    DESTROY = -197
+    #/** Generic failure */
+    FAIL = -196
+    #/** Broker transport failure */
+    TRANSPORT = -195
+    #/** Critical system resource */
+    CRIT_SYS_RESOURCE = -194
+    #/** Failed to resolve broker */
+    RESOLVE = -193
+    #/** Produced message timed out*/
+    MSG_TIMED_OUT = -192
+    #/** Reached the end of the topic+partition queue on
+    # * the broker. Not really an error.
+    # * This event is disabled by default,
+    # * see the `enable.partition.eof` configuration property. */
+    PARTITION_EOF = -191
+    # /** Permanent: Partition does not exist in cluster. */
+    UNKNOWN_PARTITION = -190
+    #/** File or filesystem error */
+    FS = -189
+    #/** Permanent: Topic does not exist in cluster. */
+    UNKNOWN_TOPIC = -188
+    #/** All broker connections are down. */
+    ALL_BROKERS_DOWN = -187
+    #/** Invalid argument, or invalid configuration */
+    INVALID_ARG = -186
+    #/** Operation timed out */
+    TIMED_OUT = -185
+    #/** Queue is full */
+    QUEUE_FULL = -184
+    #/** ISR count < required.acks */
+    ISR_INSUFF = -183
+    #/** Broker node update */
+    NODE_UPDATE = -182
+    #/** SSL error */
+    SSL = -181
+    #/** Waiting for coordinator to become available. */
+    WAIT_COORD = -180
+    #/** Unknown client group */
+    UNKNOWN_GROUP = -179
+    #/** Operation in progress */
+    IN_PROGRESS = -178
+    #/** Previous operation in progress, wait for it to finish. */
+    PREV_IN_PROGRESS = -177
+    #/** This operation would interfere with an existing subscription */
+    EXISTING_SUBSCRIPTION = -176
+    #/** Assigned partitions (rebalance_cb) */
+    ASSIGN_PARTITIONS = -175
+    #/** Revoked partitions (rebalance_cb) */
+    REVOKE_PARTITIONS = -174
+    #/** Conflicting use */
+    CONFLICT = -173
+    #/** Wrong state */
+    STATE = -172
+    #/** Unknown protocol */
+    UNKNOWN_PROTOCOL = -171
+    #/** Not implemented */
+    NOT_IMPLEMENTED = -170
+    #/** Authentication failure*/
+    AUTHENTICATION = -169
+    #/** No stored offset */
+    NO_OFFSET = -168
+    #/** Outdated */
+    OUTDATED = -167
+    #/** Timed out in queue */
+    TIMED_OUT_QUEUE = -166
+    #/** Feature not supported by broker */
+    UNSUPPORTED_FEATURE = -165
+    #/** Awaiting cache update */
+    WAIT_CACHE = -164
+    #/** Operation interrupted (e.g., due to yield)) */
+    INTR = -163
+    #/** Key serialization error */
+    KEY_SERIALIZATION = -162
+    #/** Value serialization error */
+    VALUE_SERIALIZATION = -161
+    #/** Key deserialization error */
+    KEY_DESERIALIZATION = -160
+    #/** Value deserialization error */
+    VALUE_DESERIALIZATION = -159
+    #/** Partial response */
+    PARTIAL = -158
+    #/** Modification attempted on read-only object */
+    READ_ONLY = -157
+    #/** No such entry / item not found */
+    NOENT = -156
+    #/** Read underflow */
+    UNDERFLOW = -155
+    #/** Invalid type */
+    INVALID_TYPE = -154
+    #/** Retry operation */
+    RETRY = -153
+    #/** Purged in queue */
+    PURGE_QUEUE = -152
+    #/** Purged in flight */
+    PURGE_INFLIGHT = -151
+    #/** Fatal error: see rd_kafka_fatal_error() */
+    FATAL = -150
+    #/** Inconsistent state */
+    INCONSISTENT = -149
+    #/** Gap-less ordering would not be guaranteed if proceeding */
+    GAPLESS_GUARANTEE = -148
+    #/** Maximum poll interval exceeded */
+    MAX_POLL_EXCEEDED = -147
+    #/** Unknown broker */
+    UNKNOWN_BROKER = -146
+    #/** Functionality not configured */
+    NOT_CONFIGURED = -145
+    #/** Instance has been fenced */
+    FENCED = -144
+    #/** Application generated error */
+    APPLICATION = -143
 
-OFFSET_BEGINNING = -2_i64  # /**< Start consuming from beginning of
-OFFSET_END       = -1_i64  # /**< Start consuming from end of kafka
+    #/** End internal error codes */
+    END_INTERNAL_ERROR = -100
 
+    #/* Kafka broker errors: */
+    #/** Unknown broker error */
+    UNKNOWN = -1
+    #/** Success */
+    NO_ERROR = 0
+    #/** Offset out of range */
+    OFFSET_OUT_OF_RANGE = 1
+    #/** Invalid message */
+    INVALID_MSG = 2
+    #/** Unknown topic or partition */
+    UNKNOWN_TOPIC_OR_PART = 3
+    #/** Invalid message size */
+    INVALID_MSG_SIZE = 4
+    #/** Leader not available */
+    LEADER_NOT_AVAILABLE = 5
+    #/** Not leader for partition */
+    NOT_LEADER_FOR_PARTITION = 6
+    #/** Request timed out */
+    REQUEST_TIMED_OUT = 7
+    #/** Broker not available */
+    BROKER_NOT_AVAILABLE = 8
+    #/** Replica not available */
+    REPLICA_NOT_AVAILABLE = 9
+    #/** Message size too large */
+    MSG_SIZE_TOO_LARGE = 10
+    #/** StaleControllerEpochCode */
+    STALE_CTRL_EPOCH = 11
+    #/** Offset metadata string too large */
+    OFFSET_METADATA_TOO_LARGE = 12
+    #/** Broker disconnected before response received */
+    NETWORK_EXCEPTION = 13
+    #/** Coordinator load in progress */
+    COORDINATOR_LOAD_IN_PROGRESS = 14
+    #/** Coordinator not available */
+    COORDINATOR_NOT_AVAILABLE = 15
+    #/** Not coordinator */
+    NOT_COORDINATOR = 16
+    #/** Invalid topic */
+    TOPIC_EXCEPTION = 17
+    #/** Message batch larger than configured server segment size */
+    RECORD_LIST_TOO_LARGE = 18
+    #/** Not enough in-sync replicas */
+    NOT_ENOUGH_REPLICAS = 19
+    #/** Message(s) written to insufficient number of in-sync replicas */
+    NOT_ENOUGH_REPLICAS_AFTER_APPEND = 20
+    #/** Invalid required acks value */
+    INVALID_REQUIRED_ACKS = 21
+    #/** Specified group generation id is not valid */
+    ILLEGAL_GENERATION = 22
+    #/** Inconsistent group protocol */
+    INCONSISTENT_GROUP_PROTOCOL = 23
+    #/** Invalid group.id */
+    INVALID_GROUP_ID = 24
+    #/** Unknown member */
+    UNKNOWN_MEMBER_ID = 25
+    #/** Invalid session timeout */
+    INVALID_SESSION_TIMEOUT = 26
+    #/** Group rebalance in progress */
+    REBALANCE_IN_PROGRESS = 27
+    #/** Commit offset data size is not valid */
+    INVALID_COMMIT_OFFSET_SIZE = 28
+    #/** Topic authorization failed */
+    TOPIC_AUTHORIZATION_FAILED = 29
+    #/** Group authorization failed */
+    GROUP_AUTHORIZATION_FAILED = 30
+    #/** Cluster authorization failed */
+    CLUSTER_AUTHORIZATION_FAILED = 31
+    #/** Invalid timestamp */
+    INVALID_TIMESTAMP = 32
+    #/** Unsupported SASL mechanism */
+    UNSUPPORTED_SASL_MECHANISM = 33
+    #/** Illegal SASL state */
+    ILLEGAL_SASL_STATE = 34
+    #/** Unuspported version */
+    UNSUPPORTED_VERSION = 35
+    #/** Topic already exists */
+    TOPIC_ALREADY_EXISTS = 36
+    #/** Invalid number of partitions */
+    INVALID_PARTITIONS = 37
+    #/** Invalid replication factor */
+    INVALID_REPLICATION_FACTOR = 38
+    #/** Invalid replica assignment */
+    INVALID_REPLICA_ASSIGNMENT = 39
+    #/** Invalid config */
+    INVALID_CONFIG = 40
+    #/** Not controller for cluster */
+    NOT_CONTROLLER = 41
+    #/** Invalid request */
+    INVALID_REQUEST = 42
+    #/** Message format on broker does not support request */
+    UNSUPPORTED_FOR_MESSAGE_FORMAT = 43
+    #/** Policy violation */
+    POLICY_VIOLATION = 44
+    #/** Broker received an out of order sequence number */
+    OUT_OF_ORDER_SEQUENCE_NUMBER = 45
+    #/** Broker received a duplicate sequence number */
+    DUPLICATE_SEQUENCE_NUMBER = 46
+    #/** Producer attempted an operation with an old epoch */
+    INVALID_PRODUCER_EPOCH = 47
+    #/** Producer attempted a transactional operation in an invalid state */
+    INVALID_TXN_STATE = 48
+    #/** Producer attempted to use a producer id which is not
+    # *  currently assigned to its transactional id */
+    INVALID_PRODUCER_ID_MAPPING = 49
+    #/** Transaction timeout is larger than the maximum
+    # *  value allowed by the broker's max.transaction.timeout.ms */
+    INVALID_TRANSACTION_TIMEOUT = 50
+    #/** Producer attempted to update a transaction while another
+    # *  concurrent operation on the same transaction was ongoing */
+    CONCURRENT_TRANSACTIONS = 51
+    #/** Indicates that the transaction coordinator sending a
+    # *  WriteTxnMarker is no longer the current coordinator for a
+    # *  given producer */
+    TRANSACTION_COORDINATOR_FENCED = 52
+    #/** Transactional Id authorization failed */
+    TRANSACTIONAL_ID_AUTHORIZATION_FAILED = 53
+    #/** Security features are disabled */
+    SECURITY_DISABLED = 54
+    #/** Operation not attempted */
+    OPERATION_NOT_ATTEMPTED = 55
+    #/** Disk error when trying to access log file on the disk */
+    KAFKA_STORAGE_ERROR = 56
+    #/** The user-specified log directory is not found in the broker config */
+    LOG_DIR_NOT_FOUND = 57
+    #/** SASL Authentication failed */
+    SASL_AUTHENTICATION_FAILED = 58
+    #/** Unknown Producer Id */
+    UNKNOWN_PRODUCER_ID = 59
+    #/** Partition reassignment is in progress */
+    REASSIGNMENT_IN_PROGRESS = 60
+    #/** Delegation Token feature is not enabled */
+    DELEGATION_TOKEN_AUTH_DISABLED = 61
+    #/** Delegation Token is not found on server */
+    DELEGATION_TOKEN_NOT_FOUND = 62
+    #/** Specified Principal is not valid Owner/Renewer */
+    DELEGATION_TOKEN_OWNER_MISMATCH = 63
+    #/** Delegation Token requests are not allowed on this connection */
+    DELEGATION_TOKEN_REQUEST_NOT_ALLOWED = 64
+    #/** Delegation Token authorization failed */
+    DELEGATION_TOKEN_AUTHORIZATION_FAILED = 65
+    #/** Delegation Token is expired */
+    DELEGATION_TOKEN_EXPIRED = 66
+    #/** Supplied principalType is not supported */
+    INVALID_PRINCIPAL_TYPE = 67
+    #/** The group is not empty */
+    NON_EMPTY_GROUP = 68
+    #/** The group id does not exist */
+    GROUP_ID_NOT_FOUND = 69
+    #/** The fetch session ID was not found */
+    FETCH_SESSION_ID_NOT_FOUND = 70
+    #/** The fetch session epoch is invalid */
+    INVALID_FETCH_SESSION_EPOCH = 71
+    #/** No matching listener */
+    LISTENER_NOT_FOUND = 72
+    #/** Topic deletion is disabled */
+    TOPIC_DELETION_DISABLED = 73
+    #/** Leader epoch is older than broker epoch */
+    FENCED_LEADER_EPOCH = 74
+    #/** Leader epoch is newer than broker epoch */
+    UNKNOWN_LEADER_EPOCH = 75
+    #/** Unsupported compression type */
+    UNSUPPORTED_COMPRESSION_TYPE = 76
+    #/** Broker epoch has changed */
+    STALE_BROKER_EPOCH = 77
+    #/** Leader high watermark is not caught up */
+    OFFSET_NOT_AVAILABLE = 78
+    #/** Group member needs a valid member ID */
+    MEMBER_ID_REQUIRED = 79
+    #/** Preferred leader was not available */
+    PREFERRED_LEADER_NOT_AVAILABLE = 80
+    #/** Consumer group has reached maximum size */
+    GROUP_MAX_SIZE_REACHED = 81
+    #/** Static consumer fenced by other consumer with same
+    # *  group.instance.id. */
+    FENCED_INSTANCE_ID = 82
+    #/** Eligible partition leaders are not available */
+    ELIGIBLE_LEADERS_NOT_AVAILABLE = 83
+    #/** Leader election not needed for topic partition */
+    ELECTION_NOT_NEEDED = 84
+    #/** No partition reassignment is in progress */
+    NO_REASSIGNMENT_IN_PROGRESS = 85
+    #/** Deleting offsets of a topic while the consumer group is subscribed to it */
+    GROUP_SUBSCRIBED_TO_TOPIC = 86
+    #/** Broker failed to validate record */
+    INVALID_RECORD = 87
+    #/** There are unstable offsets that need to be cleared */
+    UNSTABLE_OFFSET_COMMIT = 88
+  end
 
-PARTITION_UNASSIGNED = -1
+  MSG_FLAG_FREE = 0x1    # Delegate freeing of payload to rdkafka
+  MSG_FLAG_COPY = 0x2    # rdkafka will make a copy of the payload.
+  MSG_FLAG_BLOCK = 0x4   # Block produce*() on message queue full
+
+  OFFSET_BEGINNING = -2_i64  # /**< Start consuming from beginning of
+  OFFSET_END       = -1_i64  # /**< Start consuming from end of kafka
+
+  PARTITION_UNASSIGNED = -1
 
 struct Message
   err : Int32 #rd_kafka_resp_err_t err;   /**< Non-zero for error signaling. */
@@ -67,7 +380,7 @@ end
   fun conf_destroy = rd_kafka_conf_destroy(conf: ConfHandle)
   fun conf_set = rd_kafka_conf_set(conf: ConfHandle, name: UInt8*, value: UInt8*, errstr: UInt8*, errstr_size: LibC::SizeT) : Int32
 
-  fun conf_set_dr_msg_cb = rd_kafka_conf_set_dr_msg_cb(conf: ConfHandle, cb: (KafkaHandle, Void*, Void* ) -> )
+  fun conf_set_dr_msg_cb = rd_kafka_conf_set_dr_msg_cb(conf: ConfHandle, cb: (KafkaHandle, Message*, Void* ) -> )
 
   fun topic_conf_new = rd_kafka_topic_conf_new : TopicConf
   fun topic_conf_destroy = rd_kafka_topic_conf_destroy(tc : TopicConf)
@@ -107,7 +420,7 @@ end
   fun subscribe = rd_kafka_subscribe(rk: KafkaHandle, subscription: TopicPartitionList) : Int32
 
   fun poll = rd_kafka_poll(rk: KafkaHandle, timeout_ms: Int32) : Int32
-  fun flush = rd_kafka_flush(rk: KafkaHandle, timeout_ms: Int32)
+  fun flush = rd_kafka_flush(rk: KafkaHandle, timeout_ms: Int32) : Int32
 
   fun last_error = rd_kafka_last_error() : Int32
   fun err2str = rd_kafka_err2str(code : Int32) : UInt8*

--- a/src/kafka/producer.cr
+++ b/src/kafka/producer.cr
@@ -1,94 +1,248 @@
 require "./lib_rdkafka.cr"
 require "./config.cr"
+require "./errors"
 
 module Kafka
+  # Provides insights whether sending a message that has been previously
+  # enqueued was successful or not.
+  struct DeliveryReport
+    getter err
+
+    def initialize(@err : LibKafkaC::ResponseError)
+    end
+
+    def ok?
+      @err.no_error?
+    end
+
+    def failed?
+      !ok?
+    end
+
+    def error_message : String
+      Kafka.err2str(@err)
+    end
+
+    def to_s(io)
+      if ok?
+        io << "OK"
+      else
+        io << "Error: " << @err << " (" << error_message << ')'
+      end
+    end
+  end
+
+  # Internal class to prevent the GC from deleting the objects from the callback.
+  class PreventGC
+    @prevent_gc = Set(Pointer(Void)).new
+    @prevent_gc_mutex = Mutex.new
+
+    def protect_from_gc(box : Pointer(Void)) : Pointer(Void)
+      @prevent_gc_mutex.synchronize { @prevent_gc.add(box) }
+      box
+    end
+
+    def allow_gc(box : Pointer(Void)) : Nil
+      @prevent_gc_mutex.synchronize { @prevent_gc.delete(box) }
+    end
+  end
 
   # represents a kafka producer
   class Producer
+    class NativeResources
+      getter handle
+      getter topic : LibKafkaC::Topic?
+      @delivery_report_handler : Proc(LibKafkaC::KafkaHandle, LibKafkaC::Message*, Void*, Nil)?
+      @prevent_gc = PreventGC.new
+
+      def initialize(conf : Config, install_delivery_report_cb : Bool)
+        # Pushing a message to the queue does not guarantee that the message gets
+        # successfully delivered. To gain certainty, Kafka allows to install a
+        # callback with will include a status code indication whether sending
+        # was succesful.
+        if install_delivery_report_cb
+          callback = ->(_handle : LibKafkaC::KafkaHandle, kafka_message : LibKafkaC::Message*, _conf_opaque : Void*) {
+            msg = kafka_message.value
+            boxed_arg = msg._priv
+            channel, prevent_gc = Box({Channel(DeliveryReport), PreventGC}).unbox(boxed_arg)
+            prevent_gc.allow_gc(boxed_arg)
+            begin
+              channel.send(DeliveryReport.new(LibKafkaC::ResponseError.new(msg.err)))
+            rescue Channel::ClosedError
+              # caller is no longer interested in the delivery report
+            end
+            nil
+          }
+          conf.set_msg_callback(callback)
+          @delivery_report_handler = callback # prevent GC collection
+        end
+
+        @err_str_ptr = LibC.malloc(ERRLEN).as(UInt8*)
+        @handle = LibKafkaC.kafka_new(LibKafkaC::TYPE_PRODUCER, conf, @err_str_ptr, ERRLEN)
+        raise "Kafka: Unable to create new producer" if @handle == 0_u64
+      end
+
+      def init_topic(topic : LibKafkaC::Topic)
+        raise "Topic already initialized" if @topic
+        @topic = topic
+      end
+
+      def has_delivery_report_handler?
+        !@delivery_report_handler.nil?
+      end
+
+      def box(channel : Channel(DeliveryReport)) : Pointer(Void)
+        @prevent_gc.protect_from_gc(Box.box({channel, @prevent_gc}))
+      end
+
+      def finalize
+        @topic.try { |x| LibKafkaC.topic_destroy(x) }
+        LibKafkaC.kafka_destroy(@handle) unless @handle == 0_u64
+        LibC.free(@err_str_ptr)
+      end
+    end
+
+    class PollingFiber
+      def initialize(@native : NativeResources, @polling_interval : Time::Span)
+        @stopped = Atomic(Int32).new(0)
+      end
+
+      def start
+        spawn do
+          while !stopped?
+            LibKafkaC.poll(@native.handle, 0)
+            sleep @polling_interval
+          end
+        end
+      end
+
+      def stopped?
+        @stopped.get != 0
+      end
+
+      def stop
+        @stopped.set(1)
+      end
+
+      def finalize
+        @stopped.set(1)
+      end
+    end
+
+    @polling_fiber = Atomic(PollingFiber?).new(nil)
+    getter polling_interval
 
     # creates a new kafka handle using provided config.
     # Throws exception on error
-    def initialize(conf : Config)
-      @polling = false
-      @keep_running = true
-      @pErrStr = LibC.malloc(ERRLEN).as(UInt8*)
-      @handle = LibKafkaC.kafka_new(LibKafkaC::TYPE_PRODUCER, conf, @pErrStr, ERRLEN)
-      raise "Kafka: Unable to create new producer" if @handle == 0_u64
+    def initialize(conf : Config, *, install_delivery_report_cb = false, @polling_interval : Time::Span = 200.milliseconds)
+      @native = NativeResources.new(conf, install_delivery_report_cb)
     end
 
     # Set the topic to use for *produce()* calls.
     # Raises exception on error.
     def set_topic(name : String)
-      @topic = LibKafkaC.topic_new @handle, name, nil
-      raise "Kafka: unable to allocate topic instance #{name}" if @topic == 0_u64
+      topic = LibKafkaC.topic_new(@native.handle, name, nil)
+      raise "Kafka: unable to allocate topic instance #{name}" if topic == 0_u64
+      @native.init_topic(topic)
     end
 
     # enqueues *msg*
-    # Will start internal polling fiber, if not already started.
-    # returns true on success.  Raises exception otherwise
-    def produce(msg : String, partition : Int32 = LibKafkaC::PARTITION_UNASSIGNED, key : String? = nil, flags : Int32 = LibKafkaC::MSG_FLAG_COPY )
-
-      raise "No topic set" unless @topic
+    # Will start internal polling fiber if not already started.
+    # Returns true on success.  Raises exception otherwise
+    def produce(msg : String | Bytes, partition : Int32 = LibKafkaC::PARTITION_UNASSIGNED, key : String? = nil, flags : Int32 = LibKafkaC::MSG_FLAG_COPY) : Bool
+      unless topic = @native.topic
+        raise "No topic set"
+      end
       part = partition || LibKafkaC::PARTITION_UNASSIGNED
 
-      res = LibKafkaC.produce(@topic, part, flags, msg.to_unsafe, msg.size,
-              key, (key.nil? ? 0 : key.size), nil)
-      raise "Failed to enqueue message" if res == -1
-
-      start_polling unless @polling
-
-      return true
-    end
-
-    # :nodoc:
-    private def start_polling()
-      return if @polling
-
-      spawn do
-
-        @polling = true
-
-        while @keep_running
-
-          LibKafkaC.poll(@handle, 500)
-        end
-
-        @polling = false
+      res = LibKafkaC.produce(topic, part, flags, msg.to_unsafe, msg.size,
+        key, (key.nil? ? 0 : key.size), nil)
+      if res != LibKafkaC::OK
+        raise IO::Error.new("Failed to enqueue message (errno: #{Errno.value})")
       end
 
+      ensure_polling_fiber_is_running
+      true
     end
 
-    # Calls *flush(1000)* and will stop polling fiber, if running.
-    def stop()
-      flush(1000)
-      @keep_running = false
+    # Similar to `produce`, but allows to detect whether sending was successful or not.
+    # There are two phases that can fail (enqueuing and asynchronous sending):
+    #
+    # First, if the message cannot be enqueued, an exception will be thrown immediately.
+    # Otherwise, the sending with occur in the background. To see the results, a channel
+    # will be returned which will eventually receive the delivery report.
+    #
+    # To receive the delivery report, we are building on a Kafka's user callbacks.
+    # If you want to use this function, make sure that the option was enabled
+    # in the constructor (`install_delivery_report_cb` should be `true`).
+    #
+    # Note: Callbacks will come with a performance penality, so if throughput is more
+    # important in your use case then detecting errors, using the fire-and-forget
+    # `produce` method is recommended instead.
+    #
+    # Will start the internal polling fiber if not already started.
+    def produce_with_delivery_report(msg : String | Bytes, *, partition : Int32 = LibKafkaC::PARTITION_UNASSIGNED, key : String? = nil, flags : Int32 = LibKafkaC::MSG_FLAG_COPY) : Channel(DeliveryReport)
+      raise "No topic set" unless topic = @native.topic
+      raise "Pass 'install_delivery_report_cb=true' to the constructor" unless @native.has_delivery_report_handler?
+
+      part = partition || LibKafkaC::PARTITION_UNASSIGNED
+
+      delivery_report_channel = Channel(DeliveryReport).new(1)
+      delivery_report_callback_arg = @native.box(delivery_report_channel)
+
+      res = LibKafkaC.produce(topic, part, flags, msg.to_unsafe, msg.size,
+        key, (key.nil? ? 0 : key.size), delivery_report_callback_arg)
+      if res != LibKafkaC::OK
+        raise IO::Error.new("Failed to enqueue message (errno: #{Errno.value})")
+      end
+      ensure_polling_fiber_is_running
+      delivery_report_channel
     end
 
+    # The Kafka API requires that we call *poll* at regular intervals.
+    private def ensure_polling_fiber_is_running
+      @polling_fiber.get.try do |old_fiber|
+        return unless old_fiber.stopped?
+      end
+
+      new_fiber = PollingFiber.new(@native, @polling_interval)
+      _, changed = @polling_fiber.compare_and_set(nil, new_fiber)
+      new_fiber.start if changed
+    end
+
+    # Calls *flush* and will stop polling the fiber if running.
+    def stop(timeout = 30.seconds)
+      if old_fiber = @polling_fiber.get
+        @polling_fiber.compare_and_set(old_fiber, nil)
+        old_fiber.stop
+      end
+      flush(timeout)
+    end
+
+    def flush(timeout = 10.second) : Nil
+      case err = LibKafkaC::ResponseError.new(LibKafkaC.flush(@native.handle, timeout.total_milliseconds))
+      when .no_error?
+        nil
+      when .timed_out?
+        raise IO::TimeoutError.new
+      else
+        raise KafkaException.new("Unexpected error when flushing messages", err)
+      end
+    end
+
+    @[Deprecated("Use `#flush(Time::TimeSpan)` instead")]
     def flush(timeout_ms : Int32)
-      LibKafkaC.flush(@handle, timeout_ms)
+      LibKafkaC.flush(@native.handle, timeout_ms)
     end
 
     # returns true if polling fiber is running
-    def polling() : Bool
-      @polling
-    end
-
-    # :nodoc:
-    def finalize()
-      begin
-        LibC.free(@pErrStr)
-
-        LibKafkaC.topic_destroy(@topic) if @topic
-
-        LibKafkaC.kafka_destroy(@handle) if @handle
-      end
+    def polling : Bool
+      @polling_fiber.get
     end
 
     # :nodoc:
     def to_unsafe
-      return @handle
+      @native.handle
     end
-
   end
-
 end

--- a/src/kafka/producer.cr
+++ b/src/kafka/producer.cr
@@ -158,7 +158,7 @@ module Kafka
       res = LibKafkaC.produce(topic, part, flags, msg.to_unsafe, msg.size,
         key, (key.nil? ? 0 : key.size), nil)
       if res != LibKafkaC::OK
-        raise IO::Error.new("Failed to enqueue message (errno: #{Errno.value})")
+        raise KafkaException.new("Failed to enqueue message", Errno.value)
       end
 
       ensure_polling_fiber_is_running
@@ -193,7 +193,7 @@ module Kafka
       res = LibKafkaC.produce(topic, part, flags, msg.to_unsafe, msg.size,
         key, (key.nil? ? 0 : key.size), delivery_report_callback_arg)
       if res != LibKafkaC::OK
-        raise IO::Error.new("Failed to enqueue message (errno: #{Errno.value})")
+        raise KafkaException.new("Failed to enqueue message", Errno.value)
       end
       ensure_polling_fiber_is_running
       delivery_report_channel


### PR DESCRIPTION
* Fixed: previous poll loop blocked the event loop for 500 ms and as it was running in a loop, no other fibers had a chance to run
* "produce" accepts "String | Bytes" now to avoid that when sending Bytes, everything has to be copied to a String, first
* Added function "produce_with_delivery_report", which allows to get feedback whether the asynchronous sending succeeded.